### PR TITLE
Update El Aaiun location

### DIFF
--- a/data/countries.csv
+++ b/data/countries.csv
@@ -64,7 +64,7 @@ Algiers,Algeria,DZA,36.775348,3.060066,"Algiers, Algeria","Algiers, Alger Centre
 Quito,Ecuador,ECU,-0.155388,-78.486231,"Quito, Ecuador","Quito, Quito, Pichincha, EC"
 Cairo,Egypt,EGY,30.048819,31.243666,"Cairo, Egypt","Cairo, Cairo Governorate, EG"
 Asmara,Eritrea,ERI,15.338997,38.932673,"Asmara, Eritrea","Asmara, Maekel Region, ER"
-El Aaiún,Western Sahara,ESH,27.1241756,-13.2456082,"El Aaiún, Western Sahara",EH
+El Aaiún,Western Sahara,ESH,27.152, -13.206,"El Aaiún, Western Sahara",EH
 Madrid,Spain,ESP,40.416705,-3.703582,"Madrid, Spain","Madrid, Área metropolitana de Madrid y Corredor del Henares, Community of Madrid, ES"
 Tallinn,Estonia,EST,59.437216,24.745369,"Tallinn, Estonia","Tallinn, Harju maakond, EE"
 Addis Ababa,Ethiopia,ETH,9.010793,38.761253,"Addis Ababa, Ethiopia","Addis Ababa, Addis Ababa, ET"

--- a/data/countries_short.csv
+++ b/data/countries_short.csv
@@ -64,7 +64,7 @@ Algiers,Algeria,DZA,36.775,3.060
 Quito,Ecuador,ECU,-0.155,-78.486
 Cairo,Egypt,EGY,30.049,31.244
 Asmara,Eritrea,ERI,15.339,38.933
-El Aaiún,Western Sahara,ESH,27.124,-13.246
+El Aaiún,Western Sahara,ESH,27.152, -13.206
 Madrid,Spain,ESP,40.417,-3.704
 Tallinn,Estonia,EST,59.437,24.745
 Addis Ababa,Ethiopia,ETH,9.011,38.761


### PR DESCRIPTION
The capital of Western Sahara shows up empty in this project . . .

<img width="881" alt="screenshot 2016-05-24 10 32 27" src="https://cloud.githubusercontent.com/assets/735463/15507774/f723c24c-219a-11e6-9bcb-d11f91d26e59.png">

. . . because for some reason Mapzen Search geocoded to a spot West of the city, on the perimeter of the administrative boundary (cc @orangejulius):

<img width="870" alt="screenshot 2016-05-24 10 36 54" src="https://cloud.githubusercontent.com/assets/735463/15507923/7be99cf4-219b-11e6-9e8c-8da301e03b99.png">

This pull request updates the location to the city center, where OSM actually has fairly robust coverage. I think image export will have to run again to complete this update.
